### PR TITLE
CC-30444: Backport for Glue current locale negotiation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "spryker/kernel": "^3.52.0",
         "spryker/locale-extension": "^1.0.0",
         "spryker/propel-orm": "^1.8.0",
-        "spryker/transfer": "^3.25.0"
+        "spryker/transfer": "^3.25.0",
+        "spryker/willdurand-negotiation": "^1.0.0"
     },
     "require-dev": {
         "spryker/code-sniffer": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.52.0",
         "spryker/locale-extension": "^1.0.0",
         "spryker/propel-orm": "^1.8.0",
-        "spryker/transfer": "^3.25.0",
+        "spryker/transfer": "^3.27.0",
         "spryker/willdurand-negotiation": "^1.0.0"
     },
     "require-dev": {

--- a/dependency.json
+++ b/dependency.json
@@ -1,5 +1,5 @@
 {
     "include": {
-        "spryker/transfer": "Provides transfer objects definition with `::get*OrFail()` functionality."
+        "spryker/transfer": "Provides transfer objects definition with strict types."
     }
 }

--- a/src/Spryker/Service/Locale/Dependency/External/LocaleToLanguageNegotiatorAdapter.php
+++ b/src/Spryker/Service/Locale/Dependency/External/LocaleToLanguageNegotiatorAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale\Dependency\External;
+
+use Negotiation\AcceptLanguage;
+use Negotiation\LanguageNegotiator;
+
+class LocaleToLanguageNegotiatorAdapter implements LocaleToLanguageNegotiatorInterface
+{
+    /**
+     * @var \Negotiation\LanguageNegotiator
+     */
+    protected LanguageNegotiator $languageNegotiator;
+
+    public function __construct()
+    {
+        $this->languageNegotiator = new LanguageNegotiator();
+    }
+
+    /**
+     * @param string $acceptLanguageHeader
+     * @param array<int, string> $priorities
+     * @param bool $strict
+     *
+     * @return \Negotiation\AcceptLanguage|null
+     */
+    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguage
+    {
+        /** @var \Negotiation\AcceptLanguage|null $acceptLanguage */
+        $acceptLanguage = $this->languageNegotiator->getBest(
+            $acceptLanguageHeader,
+            $priorities,
+            $strict,
+        );
+
+        return $acceptLanguage;
+    }
+}

--- a/src/Spryker/Service/Locale/Dependency/External/LocaleToLanguageNegotiatorInterface.php
+++ b/src/Spryker/Service/Locale/Dependency/External/LocaleToLanguageNegotiatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale\Dependency\External;
+
+use Negotiation\AcceptLanguage;
+
+interface LocaleToLanguageNegotiatorInterface
+{
+    /**
+     * @param string $acceptLanguageHeader
+     * @param array<int, string> $priorities
+     * @param bool $strict
+     *
+     * @return \Negotiation\AcceptLanguage|null
+     */
+    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguage;
+}

--- a/src/Spryker/Service/Locale/LocaleDependencyProvider.php
+++ b/src/Spryker/Service/Locale/LocaleDependencyProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale;
+
+use Spryker\Service\Kernel\AbstractBundleDependencyProvider;
+use Spryker\Service\Kernel\Container;
+use Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorAdapter;
+
+class LocaleDependencyProvider extends AbstractBundleDependencyProvider
+{
+    /**
+     * @var string
+     */
+    public const LANGUAGE_NEGOTIATOR = 'LANGUAGE_NEGOTIATOR';
+
+    /**
+     * @param \Spryker\Service\Kernel\Container $container
+     *
+     * @return \Spryker\Service\Kernel\Container
+     */
+    public function provideServiceDependencies(Container $container): Container
+    {
+        $container = parent::provideServiceDependencies($container);
+
+        $container = $this->addLanguageNegotiator($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Service\Kernel\Container $container
+     *
+     * @return \Spryker\Service\Kernel\Container
+     */
+    public function addLanguageNegotiator(Container $container): Container
+    {
+        $container->set(static::LANGUAGE_NEGOTIATOR, function () {
+            return new LocaleToLanguageNegotiatorAdapter();
+        });
+
+        return $container;
+    }
+}

--- a/src/Spryker/Service/Locale/LocaleService.php
+++ b/src/Spryker/Service/Locale/LocaleService.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale;
+
+use Negotiation\AcceptLanguage;
+use Spryker\Service\Kernel\AbstractService;
+
+/**
+ * @method \Spryker\Service\Locale\LocaleServiceFactory getFactory()
+ */
+class LocaleService extends AbstractService implements LocaleServiceInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param string $acceptLanguageHeader
+     * @param array<int, string> $priorities
+     * @param bool $strict
+     *
+     * @return \Negotiation\AcceptLanguage|null
+     */
+    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguage
+    {
+        return $this->getFactory()
+            ->getLanguageNegotiator()
+            ->getAcceptLanguage($acceptLanguageHeader, $priorities, $strict);
+    }
+}

--- a/src/Spryker/Service/Locale/LocaleService.php
+++ b/src/Spryker/Service/Locale/LocaleService.php
@@ -7,7 +7,7 @@
 
 namespace Spryker\Service\Locale;
 
-use Negotiation\AcceptLanguage;
+use Generated\Shared\Transfer\AcceptLanguageTransfer;
 use Spryker\Service\Kernel\AbstractService;
 
 /**
@@ -24,12 +24,12 @@ class LocaleService extends AbstractService implements LocaleServiceInterface
      * @param array<int, string> $priorities
      * @param bool $strict
      *
-     * @return \Negotiation\AcceptLanguage|null
+     * @return \Generated\Shared\Transfer\AcceptLanguageTransfer|null
      */
-    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguage
+    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguageTransfer
     {
         return $this->getFactory()
-            ->getLanguageNegotiator()
+            ->createAcceptLanguageNegotiator()
             ->getAcceptLanguage($acceptLanguageHeader, $priorities, $strict);
     }
 }

--- a/src/Spryker/Service/Locale/LocaleServiceFactory.php
+++ b/src/Spryker/Service/Locale/LocaleServiceFactory.php
@@ -9,9 +9,32 @@ namespace Spryker\Service\Locale;
 
 use Spryker\Service\Kernel\AbstractServiceFactory;
 use Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface;
+use Spryker\Service\Locale\Mapper\AcceptLanguageMapper;
+use Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface;
+use Spryker\Service\Locale\Negotiator\AcceptLanguageNegotiator;
+use Spryker\Service\Locale\Negotiator\AcceptLanguageNegotiatorInterface;
 
 class LocaleServiceFactory extends AbstractServiceFactory
 {
+    /**
+     * @return \Spryker\Service\Locale\Negotiator\AcceptLanguageNegotiatorInterface
+     */
+    public function createAcceptLanguageNegotiator(): AcceptLanguageNegotiatorInterface
+    {
+        return new AcceptLanguageNegotiator(
+            $this->getLanguageNegotiator(),
+            $this->createAcceptLanguageMapper(),
+        );
+    }
+
+    /**
+     * @return \Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface
+     */
+    public function createAcceptLanguageMapper(): AcceptLanguageMapperInterface
+    {
+        return new AcceptLanguageMapper();
+    }
+
     /**
      * @return \Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface
      */

--- a/src/Spryker/Service/Locale/LocaleServiceFactory.php
+++ b/src/Spryker/Service/Locale/LocaleServiceFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale;
+
+use Spryker\Service\Kernel\AbstractServiceFactory;
+use Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface;
+
+class LocaleServiceFactory extends AbstractServiceFactory
+{
+    /**
+     * @return \Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface
+     */
+    public function getLanguageNegotiator(): LocaleToLanguageNegotiatorInterface
+    {
+        return $this->getProvidedDependency(LocaleDependencyProvider::LANGUAGE_NEGOTIATOR);
+    }
+}

--- a/src/Spryker/Service/Locale/LocaleServiceInterface.php
+++ b/src/Spryker/Service/Locale/LocaleServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale;
+
+use Negotiation\AcceptLanguage;
+
+interface LocaleServiceInterface
+{
+    /**
+     * Specification:
+     * - Returns the negotiated language ISO code based on the specified accept language and priorities.
+     *
+     * @api
+     *
+     * @param string $acceptLanguageHeader
+     * @param array<int, string> $priorities
+     * @param bool $strict
+     *
+     * @return \Negotiation\AcceptLanguage|null
+     */
+    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguage;
+}

--- a/src/Spryker/Service/Locale/Mapper/AcceptLanguageMapper.php
+++ b/src/Spryker/Service/Locale/Mapper/AcceptLanguageMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale\Mapper;
+
+use Generated\Shared\Transfer\AcceptLanguageTransfer;
+use Negotiation\AcceptLanguage;
+
+class AcceptLanguageMapper implements AcceptLanguageMapperInterface
+{
+    /**
+     * @param \Negotiation\AcceptLanguage $acceptLanguage
+     * @param \Generated\Shared\Transfer\AcceptLanguageTransfer $acceptLanguageTransfer
+     *
+     * @return \Generated\Shared\Transfer\AcceptLanguageTransfer
+     */
+    public function mapAcceptLanguageToAcceptLanguageTransfer(
+        AcceptLanguage $acceptLanguage,
+        AcceptLanguageTransfer $acceptLanguageTransfer
+    ): AcceptLanguageTransfer {
+        $acceptLanguageTransfer->setType($acceptLanguage->getType());
+
+        return $acceptLanguageTransfer;
+    }
+}

--- a/src/Spryker/Service/Locale/Mapper/AcceptLanguageMapperInterface.php
+++ b/src/Spryker/Service/Locale/Mapper/AcceptLanguageMapperInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale\Mapper;
+
+use Generated\Shared\Transfer\AcceptLanguageTransfer;
+use Negotiation\AcceptLanguage;
+
+interface AcceptLanguageMapperInterface
+{
+    /**
+     * @param \Negotiation\AcceptLanguage $acceptLanguage
+     * @param \Generated\Shared\Transfer\AcceptLanguageTransfer $acceptLanguageTransfer
+     *
+     * @return \Generated\Shared\Transfer\AcceptLanguageTransfer
+     */
+    public function mapAcceptLanguageToAcceptLanguageTransfer(
+        AcceptLanguage $acceptLanguage,
+        AcceptLanguageTransfer $acceptLanguageTransfer
+    ): AcceptLanguageTransfer;
+}

--- a/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiator.php
+++ b/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiator.php
@@ -14,12 +14,22 @@ use Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface;
 class AcceptLanguageNegotiator implements AcceptLanguageNegotiatorInterface
 {
     /**
+     * @var \Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface
+     */
+    protected LocaleToLanguageNegotiatorInterface $languageNegotiator;
+
+    /**
+     * @var \Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface
+     */
+    protected AcceptLanguageMapperInterface $acceptLanguageMapper;
+
+    /**
      * @param \Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface $languageNegotiator
      * @param \Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface $acceptLanguageMapper
      */
     public function __construct(
-        protected LocaleToLanguageNegotiatorInterface $languageNegotiator,
-        protected AcceptLanguageMapperInterface $acceptLanguageMapper
+        LocaleToLanguageNegotiatorInterface $languageNegotiator,
+        AcceptLanguageMapperInterface $acceptLanguageMapper
     ) {
         $this->languageNegotiator = $languageNegotiator;
         $this->acceptLanguageMapper = $acceptLanguageMapper;

--- a/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiator.php
+++ b/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Service\Locale\Negotiator;
+
+use Generated\Shared\Transfer\AcceptLanguageTransfer;
+use Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface;
+use Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface;
+
+class AcceptLanguageNegotiator implements AcceptLanguageNegotiatorInterface
+{
+    /**
+     * @param \Spryker\Service\Locale\Dependency\External\LocaleToLanguageNegotiatorInterface $languageNegotiator
+     * @param \Spryker\Service\Locale\Mapper\AcceptLanguageMapperInterface $acceptLanguageMapper
+     */
+    public function __construct(
+        protected LocaleToLanguageNegotiatorInterface $languageNegotiator,
+        protected AcceptLanguageMapperInterface $acceptLanguageMapper
+    ) {
+        $this->languageNegotiator = $languageNegotiator;
+        $this->acceptLanguageMapper = $acceptLanguageMapper;
+    }
+
+    /**
+     * @param string $acceptLanguageHeader
+     * @param array<int, string> $priorities
+     * @param bool $strict
+     *
+     * @return \Generated\Shared\Transfer\AcceptLanguageTransfer|null
+     */
+    public function getAcceptLanguage(
+        string $acceptLanguageHeader,
+        array $priorities,
+        bool $strict = false
+    ): ?AcceptLanguageTransfer {
+        $acceptLanguage = $this->languageNegotiator->getAcceptLanguage($acceptLanguageHeader, $priorities, $strict);
+
+        if (!$acceptLanguage) {
+            return null;
+        }
+
+        return $this->acceptLanguageMapper->mapAcceptLanguageToAcceptLanguageTransfer($acceptLanguage, new AcceptLanguageTransfer());
+    }
+}

--- a/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiatorInterface.php
+++ b/src/Spryker/Service/Locale/Negotiator/AcceptLanguageNegotiatorInterface.php
@@ -5,23 +5,22 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spryker\Service\Locale;
+namespace Spryker\Service\Locale\Negotiator;
 
 use Generated\Shared\Transfer\AcceptLanguageTransfer;
 
-interface LocaleServiceInterface
+interface AcceptLanguageNegotiatorInterface
 {
     /**
-     * Specification:
-     * - Returns the negotiated language ISO code based on the specified accept language and priorities.
-     *
-     * @api
-     *
      * @param string $acceptLanguageHeader
      * @param array<int, string> $priorities
      * @param bool $strict
      *
      * @return \Generated\Shared\Transfer\AcceptLanguageTransfer|null
      */
-    public function getAcceptLanguage(string $acceptLanguageHeader, array $priorities, bool $strict = false): ?AcceptLanguageTransfer;
+    public function getAcceptLanguage(
+        string $acceptLanguageHeader,
+        array $priorities,
+        bool $strict = false
+    ): ?AcceptLanguageTransfer;
 }

--- a/src/Spryker/Shared/Locale/Transfer/locale.transfer.xml
+++ b/src/Spryker/Shared/Locale/Transfer/locale.transfer.xml
@@ -24,4 +24,8 @@
         <property name="scope" type="string"/>
         <property name="permissionMask" type="int"/>
     </transfer>
+
+    <transfer name="AcceptLanguage" strict="true">
+        <property name="type" type="string"/>
+    </transfer>
 </transfers>

--- a/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
+++ b/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Service\Locale\LocaleService;
+
+use Codeception\Test\Unit;
+use Spryker\Service\Locale\LocaleService;
+use Spryker\Service\Locale\LocaleServiceInterface;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Service
+ * @group Locale
+ * @group LocaleService
+ * @group GetAcceptLanguageTest
+ * Add your own group annotations below this line
+ */
+class GetAcceptLanguageTest extends Unit
+{
+    /**
+     * @var \Spryker\Service\Locale\LocaleServiceInterface
+     */
+    protected LocaleServiceInterface $localeService;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->localeService = new LocaleService();
+    }
+
+    /**
+     * @dataProvider getAcceptLanguageDataProvider
+     *
+     * @param string $acceptLanguageHeader
+     * @param <int, string> $priorities
+     * @param string|null $expected
+     *
+     * @return void
+     */
+    public function testShouldReturnExpectedAcceptLanguageType(string $acceptLanguageHeader, array $priorities, ?string $expected): void
+    {
+        // Act
+        $acceptLanguage = $this->localeService->getAcceptLanguage($acceptLanguageHeader, $priorities);
+
+        // Assert
+        if (!$acceptLanguage) {
+            $this->assertNull($acceptLanguage);
+        } else {
+            $this->assertSame($expected, $acceptLanguage->getType());
+        }
+    }
+
+    /**
+     * @return list<array>
+     */
+    protected function getAcceptLanguageDataProvider(): array
+    {
+        return [
+            ['en, de', ['fr'], null],
+            ['foo, bar, yo', ['baz', 'biz'], null],
+            ['fr-FR, en;q=0.8', ['en-US', 'de-DE'], 'en-us'],
+            ['en, *;q=0.9', ['fr'], 'fr'],
+            ['foo, bar, yo', ['yo'], 'yo'],
+            ['en; q=0.1, fr; q=0.4, bu; q=1.0', ['en', 'fr'], 'fr'],
+            ['en; q=0.1, fr; q=0.4, fu; q=0.9, de; q=0.2', ['en', 'fu'], 'fu'],
+            ['fr, zh-Hans-CN;q=0.3', ['fr'], 'fr'],
+            ['en;q=0.5,de', ['de;q=0.3', 'en;q=0.9'], 'en'],
+            ['fr-FR, en-US;q=0.8', ['fr'], 'fr'],
+            ['fr-FR, en-US;q=0.8', ['fr-CA', 'en'], 'en'],
+        ];
+    }
+}

--- a/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
+++ b/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
@@ -50,18 +50,20 @@ class GetAcceptLanguageTest extends Unit
     public function testShouldReturnExpectedAcceptLanguageType(string $acceptLanguageHeader, array $priorities, ?string $expected): void
     {
         // Act
-        $acceptLanguage = $this->localeService->getAcceptLanguage($acceptLanguageHeader, $priorities);
+        $acceptedLanguageTransfer = $this->localeService->getAcceptLanguage($acceptLanguageHeader, $priorities);
 
         // Assert
-        if (!$acceptLanguage) {
-            $this->assertNull($acceptLanguage);
-        } else {
-            $this->assertSame($expected, $acceptLanguage->getType());
+        if (!$acceptedLanguageTransfer) {
+            $this->assertNull($acceptedLanguageTransfer);
+
+            return;
         }
+
+        $this->assertSame($expected, $acceptedLanguageTransfer->getType());
     }
 
     /**
-     * @return list<array>
+     * @return list<array<string, list<string>, string|null>>
      */
     protected function getAcceptLanguageDataProvider(): array
     {

--- a/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
+++ b/tests/SprykerTest/Service/Locale/LocaleService/GetAcceptLanguageTest.php
@@ -42,7 +42,7 @@ class GetAcceptLanguageTest extends Unit
      * @dataProvider getAcceptLanguageDataProvider
      *
      * @param string $acceptLanguageHeader
-     * @param <int, string> $priorities
+     * @param list<string> $priorities
      * @param string|null $expected
      *
      * @return void
@@ -50,16 +50,16 @@ class GetAcceptLanguageTest extends Unit
     public function testShouldReturnExpectedAcceptLanguageType(string $acceptLanguageHeader, array $priorities, ?string $expected): void
     {
         // Act
-        $acceptedLanguageTransfer = $this->localeService->getAcceptLanguage($acceptLanguageHeader, $priorities);
+        $acceptLanguageTransfer = $this->localeService->getAcceptLanguage($acceptLanguageHeader, $priorities);
 
         // Assert
-        if (!$acceptedLanguageTransfer) {
-            $this->assertNull($acceptedLanguageTransfer);
+        if (!$acceptLanguageTransfer) {
+            $this->assertNull($acceptLanguageTransfer);
 
             return;
         }
 
-        $this->assertSame($expected, $acceptedLanguageTransfer->getType());
+        $this->assertSame($expected, $acceptLanguageTransfer->getType());
     }
 
     /**

--- a/tests/SprykerTest/Service/Locale/_support/LocaleServiceTester.php
+++ b/tests/SprykerTest/Service/Locale/_support/LocaleServiceTester.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+declare(strict_types=1);
+
+namespace SprykerTest\Service\Locale;
+
+use Codeception\Actor;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantTo($text)
+ * @method void wantToTest($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ *
+ * @SuppressWarnings(\SprykerTest\Zed\Locale\PHPMD)
+ */
+class LocaleServiceTester extends Actor
+{
+    use _generated\LocaleServiceTesterActions;
+}

--- a/tests/SprykerTest/Service/Locale/codeception.yml
+++ b/tests/SprykerTest/Service/Locale/codeception.yml
@@ -1,0 +1,21 @@
+namespace: SprykerTest\Service\Locale
+
+paths:
+    tests: .
+    data: ../../../_data
+    support: _support
+    output: ../../../_output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: .
+        actor: LocaleServiceTester
+        modules:
+            enabled:
+                - Asserts
+                - \SprykerTest\Shared\Testify\Helper\Environment


### PR DESCRIPTION
Branch: backport/3.10.0
Ticket: https://spryker.atlassian.net/browse/CC-30444
Version: 3.10.0
- Strategy: Major

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   Locale  | minor                 | WilldurandNegotiation                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Locale

##### Change log

Improvements

- Introduced `LocaleServiceInterface::getAcceptLanguage()` to negotiated language ISO code based on the specified accept language and priorities.
- Introduced `AcceptLanguage` transfer.

Adjustments

- Added `LocaleToLanguageNegotiatorInterface::getAcceptLanguage()` to dependencies to provide functionality to get negotiated language iso code based on `Accept-Language` header.
- Added `WilldurandNegotiation` module to dependencies.
- Increased `Transfer` module version dependency.